### PR TITLE
Fixed the tsconfig target to es6. Bumped verison (v2.0.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2gis/mapgl-ruler",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "license": "BSD-2-Clause",
   "main": "dist/ruler.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "types": [],
-        "target": "es5",
+        "target": "es6",
         "module": "es6",
         "moduleResolution": "node",
         "lib": ["dom", "es6"],


### PR DESCRIPTION
### Changes
1. Changed the tsconfig `target` to `es6`.
2. Changed version to a new patch: 2.0.2.

The `target` change is tested locally using the `npm run docker:test` command and the demo page (`npm run dev`).