### PR TITLE
Фикс перетаскивания точек

### DIFF
--- a/src/joint.ts
+++ b/src/joint.ts
@@ -205,7 +205,9 @@ export class Joint extends Evented<EventTable> {
 
         this.emit('move', { targetData: this });
 
-        this.coordinates = this.map.unproject([ev.clientX, ev.clientY]);
+        const container = this.map.getContainer();
+
+        this.coordinates = this.map.unproject(getMousePosition(container, ev.clientX, ev.clientY));
         this.marker?.setCoordinates(this.coordinates);
     };
 

--- a/src/joint.ts
+++ b/src/joint.ts
@@ -1,5 +1,11 @@
 import { GeoPoint, TargetedEvent } from './types';
-import { createHtmlMarker, getJointDistanceText, getLabelHtml, getMarkerPopupHtml } from './utils';
+import {
+    createHtmlMarker,
+    getJointDistanceText,
+    getLabelHtml,
+    getMarkerPopupHtml,
+    getMousePosition,
+} from './utils';
 import { Evented } from './evented';
 import { style } from './style';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,3 +179,12 @@ export function getSnapPoint(map: mapgl.Map, joints: Joint[], point: ScreenPoint
 
     return { point: geoPoint, distance, segment: bestSegmentIndex };
 }
+
+export function getMousePosition(
+    container: HTMLElement,
+    clientX: number,
+    clientY: number,
+): number[] {
+    const rect = container.getBoundingClientRect();
+    return [clientX - rect.left - container.clientLeft, clientY - rect.top - container.clientTop];
+}


### PR DESCRIPTION
Поля `clientX` и `clientY` требуют дополнительной обработки, так как они возвращают координаты относительно вьюпорта окна браузера, а необходимо использовать координаты относительно контейнера карты.

Проблему можно пронаблюдать, например, вот здесь https://vetchka.ru/snippets/17499/edit Достаточно попробовать перетащить одну из точек - во время перетаскивания она будет позиционироваться неверно.

Для фикса я перенес и использовал функцию `getMousePosition` из нашего движка.

