### PR TITLE
Обновил версию actions/upload-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build container and run tests
         run: docker-compose up --build --exit-code-from test test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           path: test/screenshots/standards/**/__diff_output__/*.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build container and run tests
-        run: docker-compose up --build --exit-code-from test test
+        run: docker compose up --build --exit-code-from test test
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@
 name: Test MapGL Ruler Plugin
 
 on:
+  pull_request:
   push:
     branches:
       - '*'
@@ -26,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build container and run tests
         run: docker-compose up --build --exit-code-from test test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           path: test/screenshots/standards/**/__diff_output__/*.png

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - '*'
+      - 'master'
     tags-ignore:
       - '*'
 
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build container and run tests
-        run: docker-compose up --build --exit-code-from test test
+        run: docker compose up --build --exit-code-from test test
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:

--- a/src/joint.ts
+++ b/src/joint.ts
@@ -43,11 +43,8 @@ export class Joint extends Evented<EventTable> {
         distance: number,
         enableOnInit,
         private showLabel: boolean,
-        private renderCustomMarker: JointFactory = (
-            map,
-            coordinates,
-            { isFirst, interactive },
-        ) => createHtmlMarker(map, coordinates, { big: isFirst, interactive }),
+        private renderCustomMarker: JointFactory = (map, coordinates, { isFirst, interactive }) =>
+            createHtmlMarker(map, coordinates, { big: isFirst, interactive }),
     ) {
         super();
         this.id = ++lastId;


### PR DESCRIPTION
Из-за устаревшей версии actions начали падать джобы (https://github.com/2gis/mapgl-ruler/actions/runs/11015870765/job/30589975237), поэтому пришлось обновить. 

Кроме того, сделал, чтобы тесты запускались на пулл-реквестах, а то почему-то в [этом PR](https://github.com/2gis/mapgl-ruler/pull/38/checks) этого не происходило.

